### PR TITLE
Update the scripts that build the books

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+#ignores output from ./scripts/buildGuides.sh
+
+#manually ignoring build dirs, 
+#feel free to make this better with a regex
+
+*~
+build/
+html/
+.zanata-cache/
+.DS_Store
+*/.DS_Store
+*.zip
+emender/results/*
+

--- a/docs/my-title-a/buildGuides.sh
+++ b/docs/my-title-a/buildGuides.sh
@@ -1,35 +1,52 @@
 # Establish global variables to the docs and script dirs
 CURRENT_DIR="$( pwd -P)"
 SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
-DOCS_SRC="${SCRIPT_SRC%/*/*}/docs"
+DOCS_SRC=$CURRENT_DIR
+
+BUILD_RESULTS="Build Results:"
+BUILD_MESSAGE=$BUILD_RESULTS
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+NO_COLOR="\033[0m"
 
 # Do not produce pot/po by default
 L10N=
 # A comma separated lists of default locales that books should be translated to.
-# This can be overriden in each book's individual buildGuides.sh
+# This can be overriden in each book's individual buildGuide.sh
 LANG_CODE=ja-JP
 
 usage(){
   cat <<EOM
-USAGE: $0 [OPTION]... <guide>
+USAGE: $0 [OPTION]... <book>
 
-DESCRIPTION: Build all of the books (default) or a single book.
+DESCRIPTION: Build all of the books (default), a single book, and (optionally)
+produce pot/po files for translation.
 
-Run this script from either the root of your cloned repository or from the 'scripts' directory.  Example:
-  cd MY_DOCUMENTATION_REPOSITORY/resources/scripts
+Run this script from root of the book directory, for example:
+  cd docs/my-title-a
   $0
 
 OPTIONS:
   -h       Print help.
+  -t       Produce the pot/po files for the designtated book(s)
 
 EXAMPLES:
-  Build all guides:
+  Build all books:
    $0
 
-  Build a specific guide(s) from $DOCS_SRC:
-    $0 my-title-a
-    $0 my-title-b
-    $0 my-title-c
+   Build all books and produce pot/po:
+    $0 -t
+
+  Build a specific book(s) from $DOCS_SRC:
+    $0 enterprise
+    $0 upstream-1
+    $0 enterprise upstream-1
+
+    Build a specific book(s) from $DOCS_SRC with pot/po:
+      $0 -t enterprise
+      $0 -t upstream-1
+      $0 -t enterprise upstream-1
+
 EOM
 # Now list the valid book values
 listvalidbooks
@@ -49,11 +66,12 @@ listvalidbooks(){
   cd $CURRENT_DIR
 }
 
-
 OPTIND=1
-while getopts "h" c
+
+while getopts "ht" c
  do
      case "$c" in
+       t)         L10N="-t $LANG_CODE";;
        h)         usage
                   exit 1;;
        \?)        echo "Unknown option: -$OPTARG." >&2
@@ -69,21 +87,17 @@ cd $DOCS_SRC
 # Set the list of docs to build to whatever the user passed in (if anyting)
 subdirs=$@
 if [ $# -gt 0 ]; then
-  echo "=== Bulding only $@ ==="
+  echo ""
+  echo "=== Bulding $@ ==="
 else
-  echo "=== Building all the books ==="
+  echo ""
+  echo "=== Building all the books for $CURRENT_DIR ==="
   # Recurse through the book directories and build them.
-
-  # The following is the original command that worked with the EAP structure:
-   # subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" | sort`
-
-   # This should work for the multi-topic-level structure but has not been tested:
-  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" ! -iname "shared" | sort`
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" | sort`
 fi
 
 for subdir in $subdirs
 do
-  echo ""
   echo "Building $DOCS_SRC/${subdir##*/}"
   # Navigate to the dirctory and build it
   if ! [ -e $DOCS_SRC/${subdir##*/} ]; then
@@ -94,7 +108,7 @@ do
   fi
   cd $DOCS_SRC/${subdir##*/}
   GUIDE_NAME=${PWD##*/}
-  ./buildGuides.sh $L10N
+  ./buildGuide.sh $L10N
   if [ "$?" = "1" ]; then
     BUILD_ERROR="ERROR: Build of $GUIDE_NAME failed. See the log above for details."
     BUILD_MESSAGE="$BUILD_MESSAGE\n$BUILD_ERROR"
@@ -106,5 +120,17 @@ done
 # Return to where we started as a courtesy.
 cd $CURRENT_DIR
 
-# Errors are reported at the book level, so we can just exit here.
+# Report any errors
+echo ""
+if [ "$BUILD_MESSAGE" == "$BUILD_RESULTS" ]; then
+  echo "Build was successful!"
+else
+  echo -e "${RED}$BUILD_MESSAGE${NO_COLOR}"
+  if [ "$LIST_BOOKS" ]; then
+    listvalidbooks
+  else
+    # This is a build error.
+    echo -e "${RED}Please fix all issues before requesting a merge!${NO_COLOR}"
+  fi
+fi
 exit;

--- a/docs/my-title-a/enterprise/buildGuide.sh
+++ b/docs/my-title-a/enterprise/buildGuide.sh
@@ -1,0 +1,79 @@
+# Build the guide
+
+# Find the directory name and full path
+CURRENT_GUIDE=${PWD##*/}
+CURRENT_DIRECTORY=$(pwd)
+RED='\033[0;31m'
+BLACK='\033[0;30m'
+# Do not produce pot/po by default
+L10N=0
+# A comma separated lists of default locales that books should be translated to.
+# This can be overriden in each book's individual buildGuide.sh
+LANG_CODE=ja-JP
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]
+
+DESCRIPTION: Build the documentation in this directory and (optionally)
+the associated L10N pot/po files.
+
+OPTIONS:
+  -h       Print help.
+  -t       Produce the L10N pot/po files for this documentation
+
+EOM
+}
+
+while getopts "ht:" c
+ do
+     case "$c" in
+       t)         L10N=1
+                  LANG_CODE=$OPTARG;;
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+done
+
+if [ $L10N -eq 1 ]; then
+   echo "Building pot/po for $CURRENT_GUIDE"
+   ccutil translate --langs $LANG_CODE
+fi
+
+# Remove the html and build directories and then recreate the html/images/ directory
+if [ -d html ]; then
+   rm -r html/
+fi
+if [ -d build ]; then
+   rm -r build/
+fi
+
+mkdir -p html
+cp -r topics/shared/images/ html/
+
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                "
+echo "********************************************"
+echo ""
+echo "Building an asciidoctor version of the $CURRENT_GUIDE"
+asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+
+echo "Building the ccutil version of the $CURRENT_GUIDE"
+ccutil compile --lang en_US --format html-single --main-file master.adoc
+
+cd ..
+
+echo "$CURRENT_GUIDE (AsciiDoctor) is located at: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html
+
+if [ -d  $CURRENT_DIRECTORY/build/tmp/en-US/html-single/ ]; then
+  echo "$CURRENT_GUIDE (ccutil) is located at: " file://$CURRENT_DIRECTORY/build/tmp/en-US/html-single/index.html
+  exit 0
+else
+  echo -e "${RED}Build of $CURRENT_GUIDE failed!"
+  echo -e "${BLACK}See the log above for details."
+  exit 1
+fi

--- a/docs/my-title-a/upstream-1/buildGuide.sh
+++ b/docs/my-title-a/upstream-1/buildGuide.sh
@@ -1,0 +1,79 @@
+# Build the guide
+
+# Find the directory name and full path
+CURRENT_GUIDE=${PWD##*/}
+CURRENT_DIRECTORY=$(pwd)
+RED='\033[0;31m'
+BLACK='\033[0;30m'
+# Do not produce pot/po by default
+L10N=0
+# A comma separated lists of default locales that books should be translated to.
+# This can be overriden in each book's individual buildGuide.sh
+LANG_CODE=ja-JP
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]
+
+DESCRIPTION: Build the documentation in this directory and (optionally)
+the associated L10N pot/po files.
+
+OPTIONS:
+  -h       Print help.
+  -t       Produce the L10N pot/po files for this documentation
+
+EOM
+}
+
+while getopts "ht:" c
+ do
+     case "$c" in
+       t)         L10N=1
+                  LANG_CODE=$OPTARG;;
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+done
+
+if [ $L10N -eq 1 ]; then
+   echo "Building pot/po for $CURRENT_GUIDE"
+   ccutil translate --langs $LANG_CODE
+fi
+
+# Remove the html and build directories and then recreate the html/images/ directory
+if [ -d html ]; then
+   rm -r html/
+fi
+if [ -d build ]; then
+   rm -r build/
+fi
+
+mkdir -p html
+cp -r topics/shared/images/ html/
+
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                "
+echo "********************************************"
+echo ""
+echo "Building an asciidoctor version of the $CURRENT_GUIDE"
+asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+
+echo "Building the ccutil version of the $CURRENT_GUIDE"
+ccutil compile --lang en_US --format html-single --main-file master.adoc
+
+cd ..
+
+echo "$CURRENT_GUIDE (AsciiDoctor) is located at: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html
+
+if [ -d  $CURRENT_DIRECTORY/build/tmp/en-US/html-single/ ]; then
+  echo "$CURRENT_GUIDE (ccutil) is located at: " file://$CURRENT_DIRECTORY/build/tmp/en-US/html-single/index.html
+  exit 0
+else
+  echo -e "${RED}Build of $CURRENT_GUIDE failed!"
+  echo -e "${BLACK}See the log above for details."
+  exit 1
+fi

--- a/docs/my-title-a/upstream-1/master-docinfo.xml
+++ b/docs/my-title-a/upstream-1/master-docinfo.xml
@@ -1,9 +1,9 @@
 <title>{MyTitleABookName}</title>
-<productname>{ProductName}</productname>
-<productnumber>{DocInfoProductNumber}</productnumber>
-<subtitle>For Use with {ProductName} {ProductRelease}</subtitle>
+<productname>{ProjectName}</productname>
+<productnumber>{DocInfoProjectNumber}</productnumber>
+<subtitle>For Use with {ProjectName} {ProjectRelease}</subtitle>
 <abstract>
-    <para>This documentation does ABC for {ProductName} {ProductRelease}.</para>
+    <para>This community documentation does ABC for {ProjectName} {ProjectRelease}.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/docs/my-title-b/buildGuides.sh
+++ b/docs/my-title-b/buildGuides.sh
@@ -1,35 +1,52 @@
 # Establish global variables to the docs and script dirs
 CURRENT_DIR="$( pwd -P)"
 SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
-DOCS_SRC="${SCRIPT_SRC%/*/*}/docs"
+DOCS_SRC=$CURRENT_DIR
+
+BUILD_RESULTS="Build Results:"
+BUILD_MESSAGE=$BUILD_RESULTS
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+NO_COLOR="\033[0m"
 
 # Do not produce pot/po by default
 L10N=
 # A comma separated lists of default locales that books should be translated to.
-# This can be overriden in each book's individual buildGuides.sh
+# This can be overriden in each book's individual buildGuide.sh
 LANG_CODE=ja-JP
 
 usage(){
   cat <<EOM
-USAGE: $0 [OPTION]... <guide>
+USAGE: $0 [OPTION]... <book>
 
-DESCRIPTION: Build all of the books (default) or a single book.
+DESCRIPTION: Build all of the books (default), a single book, and (optionally)
+produce pot/po files for translation.
 
-Run this script from either the root of your cloned repository or from the 'scripts' directory.  Example:
-  cd MY_DOCUMENTATION_REPOSITORY/resources/scripts
+Run this script from root of the book directory, for example:
+  cd docs/my-title-a
   $0
 
 OPTIONS:
   -h       Print help.
+  -t       Produce the pot/po files for the designtated book(s)
 
 EXAMPLES:
-  Build all guides:
+  Build all books:
    $0
 
-  Build a specific guide(s) from $DOCS_SRC:
-    $0 my-title-a
-    $0 my-title-b
-    $0 my-title-c
+   Build all books and produce pot/po:
+    $0 -t
+
+  Build a specific book(s) from $DOCS_SRC:
+    $0 enterprise
+    $0 upstream-1
+    $0 enterprise upstream-1
+
+    Build a specific book(s) from $DOCS_SRC with pot/po:
+      $0 -t enterprise
+      $0 -t upstream-1
+      $0 -t enterprise upstream-1
+
 EOM
 # Now list the valid book values
 listvalidbooks
@@ -49,11 +66,12 @@ listvalidbooks(){
   cd $CURRENT_DIR
 }
 
-
 OPTIND=1
-while getopts "h" c
+
+while getopts "ht" c
  do
      case "$c" in
+       t)         L10N="-t $LANG_CODE";;
        h)         usage
                   exit 1;;
        \?)        echo "Unknown option: -$OPTARG." >&2
@@ -69,21 +87,17 @@ cd $DOCS_SRC
 # Set the list of docs to build to whatever the user passed in (if anyting)
 subdirs=$@
 if [ $# -gt 0 ]; then
-  echo "=== Bulding only $@ ==="
+  echo ""
+  echo "=== Bulding $@ ==="
 else
-  echo "=== Building all the books ==="
+  echo ""
+  echo "=== Building all the books for $CURRENT_DIR ==="
   # Recurse through the book directories and build them.
-
-  # The following is the original command that worked with the EAP structure:
-   # subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" | sort`
-
-   # This should work for the multi-topic-level structure but has not been tested:
-  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" ! -iname "shared" | sort`
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" | sort`
 fi
 
 for subdir in $subdirs
 do
-  echo ""
   echo "Building $DOCS_SRC/${subdir##*/}"
   # Navigate to the dirctory and build it
   if ! [ -e $DOCS_SRC/${subdir##*/} ]; then
@@ -94,7 +108,7 @@ do
   fi
   cd $DOCS_SRC/${subdir##*/}
   GUIDE_NAME=${PWD##*/}
-  ./buildGuides.sh $L10N
+  ./buildGuide.sh $L10N
   if [ "$?" = "1" ]; then
     BUILD_ERROR="ERROR: Build of $GUIDE_NAME failed. See the log above for details."
     BUILD_MESSAGE="$BUILD_MESSAGE\n$BUILD_ERROR"
@@ -106,5 +120,17 @@ done
 # Return to where we started as a courtesy.
 cd $CURRENT_DIR
 
-# Errors are reported at the book level, so we can just exit here.
+# Report any errors
+echo ""
+if [ "$BUILD_MESSAGE" == "$BUILD_RESULTS" ]; then
+  echo "Build was successful!"
+else
+  echo -e "${RED}$BUILD_MESSAGE${NO_COLOR}"
+  if [ "$LIST_BOOKS" ]; then
+    listvalidbooks
+  else
+    # This is a build error.
+    echo -e "${RED}Please fix all issues before requesting a merge!${NO_COLOR}"
+  fi
+fi
 exit;

--- a/docs/my-title-b/enterprise/buildGuide.sh
+++ b/docs/my-title-b/enterprise/buildGuide.sh
@@ -1,0 +1,79 @@
+# Build the guide
+
+# Find the directory name and full path
+CURRENT_GUIDE=${PWD##*/}
+CURRENT_DIRECTORY=$(pwd)
+RED='\033[0;31m'
+BLACK='\033[0;30m'
+# Do not produce pot/po by default
+L10N=0
+# A comma separated lists of default locales that books should be translated to.
+# This can be overriden in each book's individual buildGuide.sh
+LANG_CODE=ja-JP
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]
+
+DESCRIPTION: Build the documentation in this directory and (optionally)
+the associated L10N pot/po files.
+
+OPTIONS:
+  -h       Print help.
+  -t       Produce the L10N pot/po files for this documentation
+
+EOM
+}
+
+while getopts "ht:" c
+ do
+     case "$c" in
+       t)         L10N=1
+                  LANG_CODE=$OPTARG;;
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+done
+
+if [ $L10N -eq 1 ]; then
+   echo "Building pot/po for $CURRENT_GUIDE"
+   ccutil translate --langs $LANG_CODE
+fi
+
+# Remove the html and build directories and then recreate the html/images/ directory
+if [ -d html ]; then
+   rm -r html/
+fi
+if [ -d build ]; then
+   rm -r build/
+fi
+
+mkdir -p html
+cp -r topics/shared/images/ html/
+
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                "
+echo "********************************************"
+echo ""
+echo "Building an asciidoctor version of the $CURRENT_GUIDE"
+asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+
+echo "Building the ccutil version of the $CURRENT_GUIDE"
+ccutil compile --lang en_US --format html-single --main-file master.adoc
+
+cd ..
+
+echo "$CURRENT_GUIDE (AsciiDoctor) is located at: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html
+
+if [ -d  $CURRENT_DIRECTORY/build/tmp/en-US/html-single/ ]; then
+  echo "$CURRENT_GUIDE (ccutil) is located at: " file://$CURRENT_DIRECTORY/build/tmp/en-US/html-single/index.html
+  exit 0
+else
+  echo -e "${RED}Build of $CURRENT_GUIDE failed!"
+  echo -e "${BLACK}See the log above for details."
+  exit 1
+fi

--- a/docs/my-title-b/enterprise/master.adoc
+++ b/docs/my-title-b/enterprise/master.adoc
@@ -1,9 +1,9 @@
 include::topics/shared/attributes.adoc[]
 
-:my-title-a:
+:my-title-b:
 :product-build:
 
-= {MyTitleABookName}
+= {MyTitleBBookName}
 
 [[book_a_chapter_1]]
 == Chapter 1

--- a/docs/my-title-b/upstream-1/buildGuide.sh
+++ b/docs/my-title-b/upstream-1/buildGuide.sh
@@ -1,0 +1,79 @@
+# Build the guide
+
+# Find the directory name and full path
+CURRENT_GUIDE=${PWD##*/}
+CURRENT_DIRECTORY=$(pwd)
+RED='\033[0;31m'
+BLACK='\033[0;30m'
+# Do not produce pot/po by default
+L10N=0
+# A comma separated lists of default locales that books should be translated to.
+# This can be overriden in each book's individual buildGuide.sh
+LANG_CODE=ja-JP
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]
+
+DESCRIPTION: Build the documentation in this directory and (optionally)
+the associated L10N pot/po files.
+
+OPTIONS:
+  -h       Print help.
+  -t       Produce the L10N pot/po files for this documentation
+
+EOM
+}
+
+while getopts "ht:" c
+ do
+     case "$c" in
+       t)         L10N=1
+                  LANG_CODE=$OPTARG;;
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+done
+
+if [ $L10N -eq 1 ]; then
+   echo "Building pot/po for $CURRENT_GUIDE"
+   ccutil translate --langs $LANG_CODE
+fi
+
+# Remove the html and build directories and then recreate the html/images/ directory
+if [ -d html ]; then
+   rm -r html/
+fi
+if [ -d build ]; then
+   rm -r build/
+fi
+
+mkdir -p html
+cp -r topics/shared/images/ html/
+
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                "
+echo "********************************************"
+echo ""
+echo "Building an asciidoctor version of the $CURRENT_GUIDE"
+asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+
+echo "Building the ccutil version of the $CURRENT_GUIDE"
+ccutil compile --lang en_US --format html-single --main-file master.adoc
+
+cd ..
+
+echo "$CURRENT_GUIDE (AsciiDoctor) is located at: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html
+
+if [ -d  $CURRENT_DIRECTORY/build/tmp/en-US/html-single/ ]; then
+  echo "$CURRENT_GUIDE (ccutil) is located at: " file://$CURRENT_DIRECTORY/build/tmp/en-US/html-single/index.html
+  exit 0
+else
+  echo -e "${RED}Build of $CURRENT_GUIDE failed!"
+  echo -e "${BLACK}See the log above for details."
+  exit 1
+fi

--- a/docs/my-title-b/upstream-1/master-docinfo.xml
+++ b/docs/my-title-b/upstream-1/master-docinfo.xml
@@ -1,9 +1,9 @@
 <title>{MyTitleABookName}</title>
-<productname>{ProductName}</productname>
-<productnumber>{DocInfoProductNumber}</productnumber>
-<subtitle>For Use with {ProductName} {ProductRelease}</subtitle>
+<productname>{ProjectName}</productname>
+<productnumber>{DocInfoProjectNumber}</productnumber>
+<subtitle>For Use with {ProjectName} {ProjectRelease}</subtitle>
 <abstract>
-    <para>This documentation does ABC for {ProductName} {ProductRelease}.</para>
+    <para>This documentation does ABC for {ProjectName} {ProjectRelease}.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/docs/my-title-b/upstream-1/master.adoc
+++ b/docs/my-title-b/upstream-1/master.adoc
@@ -1,9 +1,9 @@
 include::topics/shared/attributes.adoc[]
 
-:my-title-a:
+:my-title-b:
 :product-build:
 
-= {MyTitleABookName}
+= {MyTitleBBookName}
 
 [[book_a_chapter_1]]
 == Chapter 1

--- a/shared/attributes.adoc
+++ b/shared/attributes.adoc
@@ -18,12 +18,25 @@
 :DocInfoProductName: my-red-hat-product
 :DocInfoProductNumber: 1.0
 //
-// Book Names: 
-//     Defining the book names in document attributes instead of hard-coding them in 
-//     the master.adoc files and in link references. This makes it easy to change the 
-//     book name if necessary. 
-//     Using the pattern ending in 'BookName' makes it easy to grep for occurrences 
-//     throughout the topics 
+//
+// Community project content attributes
+//
+:ProjectName: My Red Hat Project
+:ProjectShortName: My Project
+:ProjectRelease: 1
+:ProjectVersion: 1.0
+//
+// Community project documentation publishing attributes used in the master-docinfo.xml file
+//
+:DocInfoProjectName: my-red-hat-project
+:DocInfoProjectNumber: 1.0
+//
+// Book Names:
+//     Defining the book names in document attributes instead of hard-coding them in
+//     the master.adoc files and in link references. This makes it easy to change the
+//     book name if necessary.
+//     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
+//     throughout the topics
 //
 :MyTitleABookName: My Title A
 :MyTitleBBookName: My Title B


### PR DESCRIPTION
Updates in this pull request include the following:
- Add a buildGuide.sh script for each book distribution.
- Add a buildGuides.sh script for each book that calls the buildGuide.sh script for each distribution.
- Update the resources/scripts/buildGuides.sh script to build a specific book or recurse through all the books to build them.
- Added document attributes for the project distributions to use for building the doc so they are obviously different from the product doc builds.
- Updated the master-docinfo.xml files for the upstream versions to indicate they are project, not product docs.
-  Modified the my-title-b to use My Title B instead of My Title A
